### PR TITLE
Add fields in create-clj-coerce for Blob + no-arg init

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ There are several ways to authenticate, two major ones :
 ```clojure
 ;; Local credentials, require them to have been created on your side
 ;; Default project will be used
+(def client (st/init))
+;; or equivalent
 (def client (st/init {}))
 
 ;; Service account usage for portable applications

--- a/src/clj_gcloud/storage.clj
+++ b/src/clj_gcloud/storage.clj
@@ -17,7 +17,9 @@
            (com.google.common.io ByteStreams)))
 
 (create-clj-coerce BucketInfo [:name :location :storage-class])
-(create-clj-coerce Blob [:blob-id :name :content-type])
+(create-clj-coerce Blob [:blob-id :name :content-type
+                         :cache-control :create-time :update-time :delete-time
+                         :content-disposition :content-encoding :content-language])
 (create-clj-coerce BlobId [:bucket :name])
 (create-clj-coerce BlobInfo [:blob-id :cache-control :create-time :update-time :delete-time
                              :content-disposition :content-encoding :content-language :content-type])
@@ -37,9 +39,11 @@
     (.build builder)))
 
 (defn ^Storage init
-  [options]
-  (let [builder (StorageOptions/newBuilder)]
-    (build-service builder options)))
+  ([]
+   (init {}))
+  ([options]
+   (let [builder (StorageOptions/newBuilder)]
+     (build-service builder options))))
 
 ;; BUCKETS
 (defn get-bucket


### PR DESCRIPTION
I have added fields in Blob CLJ coerce (which you can get with ->clj), the same as BlobInfo which Blob extends.
Use case : detect updated blobs from :update-time to take action.

I have also added a no-arity version of 'init' (like in clj-gcloud-bigquery) equivalent to `(init {})`  
 